### PR TITLE
feat(pwa): experimentally switch to precaching from runtimeCaching

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/ui/notPullingProbabilityCalculator/NotPullingProbabilityCalculatorViewModelImpl.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/ui/notPullingProbabilityCalculator/NotPullingProbabilityCalculatorViewModelImpl.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import me.tatarka.inject.annotations.Inject
-import kotlin.math.roundToInt
 
 @Inject
 class NotPullingProbabilityCalculatorViewModelImpl(
@@ -20,8 +19,8 @@ class NotPullingProbabilityCalculatorViewModelImpl(
             NotPullingProbabilityCalculatorUiState(
                 odds = "",
                 numberOfTrials = "",
-                pullingProbability = "-",
-                notPullingProbability = "-",
+                pullingProbability = "",
+                notPullingProbability = "",
             ),
         )
     override val uiState: StateFlow<NotPullingProbabilityCalculatorUiState> = _uiState.asStateFlow()
@@ -55,24 +54,18 @@ class NotPullingProbabilityCalculatorViewModelImpl(
                 .onErr {
                     _uiState.update {
                         it.copy(
-                            notPullingProbability = "-",
-                            pullingProbability = "-",
+                            notPullingProbability = "",
+                            pullingProbability = "",
                         )
                     }
                 }
         } else {
             _uiState.update {
                 it.copy(
-                    notPullingProbability = "-",
-                    pullingProbability = "-",
+                    notPullingProbability = "",
+                    pullingProbability = "",
                 )
             }
         }
-    }
-
-    private fun Double.format(digits: Int): String {
-        var multiplier = 1.0
-        repeat(digits) { multiplier *= 10 }
-        return ((this * multiplier).roundToInt() / multiplier).toString()
     }
 }

--- a/composeApp/workbox-config-for-wasm.js
+++ b/composeApp/workbox-config-for-wasm.js
@@ -1,10 +1,8 @@
 module.exports = {
     globDirectory: "build/dist/wasmJs/productionExecutable/",
-    globPatterns: [],
+    globPatterns: ["**/*.{html,css,js,json,png,jpg,jpeg,svg,gif,webp,woff,woff2,wasm}"],
     maximumFileSizeToCacheInBytes: 10 * 1024 * 1024,
-    runtimeCaching: [{
-        urlPattern: /.+/,
-        handler: "StaleWhileRevalidate",
-    }],
+    skipWaiting: true,
+    clientsClaim: true,
     swDest: "build/dist/wasmJs/productionExecutable/serviceWorker.js",
 };


### PR DESCRIPTION
- Use `globPatterns` instead of runtime caching to test offline availability for Wasm and other assets.
- Enable `skipWaiting` and `clientsClaim` to test immediate Service Worker updates.