### PR TITLE
chore: replace deprecated dependabot reviewers with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Each line is a pattern followed by one or more owners.
+# The owners will be automatically requested for review when a PR touches matching files.
+
+*       @yuyuyuyuyu-dev

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "yuyuyuyuyu-dev"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "yuyuyuyuyu-dev"


### PR DESCRIPTION
## Summary

The `reviewers` field in `dependabot.yml` has been deprecated by GitHub. This PR migrates to the `CODEOWNERS` file instead.

## Changes

- Remove deprecated `reviewers` fields from `dependabot.yml`
- Add `.github/CODEOWNERS` to assign `@yuyuyuyuyu-dev` as the code owner for all files

This ensures that review requests are automatically sent for all PRs, including those created by Dependabot.

---

*This PR was authored by Claude (Anthropic).*