### PR TITLE
Adopt detekt default config + Compose rules; resolve the ViewModel at the nav destination

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,3 @@
 [*.{kt,kts}]
+# @Composable functions are PascalCase; don't flag them as bad function names.
 ktlint_function_naming_ignore_when_annotated_with=Composable
-ktlint_standard_no-wildcard-imports=disabled

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Check unused code
-        run: ./gradlew :composeApp:unusedCodeCheck
+      - name: Run detekt
+        run: ./gradlew :composeApp:detektAll
 
   test:
     name: Tests

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -27,64 +27,47 @@ spotless {
 }
 
 detekt {
-    source.setFrom(
-        "src/commonMain/kotlin",
-        "src/androidMain/kotlin",
-        "src/jsMain/kotlin",
-        "src/jvmMain/kotlin",
-        "src/wasmJsMain/kotlin",
-    )
+    // Start from detekt's bundled default rule set; config/detekt/detekt.yml only
+    // records deltas (rules we turn off to defer to ktlint, plus Compose tweaks).
     config.setFrom(rootProject.files("config/detekt/detekt.yml"))
-    buildUponDefaultConfig = false
+    buildUponDefaultConfig = true
     allRules = false
     parallel = true
-    basePath.set(rootDir)
-    failOnSeverity = dev.detekt.gradle.extensions.FailOnSeverity.Warning
+    basePath = rootDir
 }
 
 tasks.withType<dev.detekt.gradle.Detekt>().configureEach {
-    jvmTarget.set("11")
+    jvmTarget = "11"
+    // Never lint generated sources (KSP output, compose resource accessors, etc.).
+    // Their source roots live *under* build/, so a relative glob can't catch them;
+    // filter by absolute path instead.
+    val buildPath =
+        layout.buildDirectory
+            .get()
+            .asFile.path
+    exclude { it.file.path.startsWith(buildPath) }
     reports {
         sarif.required.set(true)
         markdown.required.set(true)
-    }
-    if (name == "detektDebugAndroid") {
-        exclude(
-            "**/Platform.android.kt",
-            "**/di/AppComponent.android.kt",
-            "**/androidMainResourceCollectors/**",
-            "**/ActualResourceCollectors.kt",
-            "**/ExpectResourceCollectors.kt",
-        )
-    }
-    if (name == "detektMainJvm") {
-        exclude(
-            "**/Platform.jvm.kt",
-            "**/di/AppComponent.jvm.kt",
-            "**/jvmMainResourceCollectors/**",
-            "**/ActualResourceCollectors.kt",
-            "**/ExpectResourceCollectors.kt",
-        )
+        html.required.set(true)
     }
 }
 
 tasks.withType<dev.detekt.gradle.DetektCreateBaselineTask>().configureEach {
-    jvmTarget.set("11")
+    jvmTarget = "11"
 }
 
-val unusedCodeCheck by tasks.registering {
+// Aggregate task: runs detekt with type resolution for every compilation/target.
+// Type resolution gives the fullest analysis (needed by several detekt rules and
+// the Compose rules).
+val detektAll by tasks.registering {
     group = "verification"
-    description = "Runs detekt checks for unused production Kotlin code."
+    description = "Runs detekt analysis (with type resolution) across all targets."
     dependsOn(
-        "detekt",
-        "detektCommonMainSourceSet",
-        "detektWebMainSourceSet",
-        "detektAndroidMainSourceSet",
-        "detektJsMainSourceSet",
-        "detektJvmMainSourceSet",
-        "detektWasmJsMainSourceSet",
         "detektDebugAndroid",
         "detektMainJvm",
+        "detektJsMainSourceSet",
+        "detektWasmJsMainSourceSet",
     )
 }
 
@@ -188,6 +171,7 @@ compose.desktop {
 }
 
 dependencies {
+    detektPlugins(libs.compose.rules.detekt)
     debugImplementation(libs.compose.uiTooling)
     add("kspCommonMainMetadata", libs.kotlin.inject.compiler)
     add("kspAndroid", libs.kotlin.inject.compiler)

--- a/composeApp/src/androidMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/MainActivity.kt
@@ -20,6 +20,6 @@ class MainActivity : ComponentActivity() {
 
 @Preview
 @Composable
-fun AppAndroidPreview() {
+private fun AppAndroidPreview() {
     App()
 }

--- a/composeApp/src/androidMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/Platform.android.kt
@@ -1,9 +1,0 @@
-package dev.yuyuyuyuyu.notpullingprobabilitycalculator
-
-import android.os.Build
-
-class AndroidPlatform : Platform {
-    override val name: String = "Android ${Build.VERSION.SDK_INT}"
-}
-
-actual fun getPlatform(): Platform = AndroidPlatform()

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/App.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/App.kt
@@ -1,9 +1,11 @@
 package dev.yuyuyuyuyu.notpullingprobabilitycalculator
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.Preview
 import dev.yuyuyuyuyu.mymaterialtheme.MyMaterialTheme
+import dev.yuyuyuyuyu.notpullingprobabilitycalculator.di.LocalAppComponent
 import dev.yuyuyuyuyu.notpullingprobabilitycalculator.di.createAppComponent
 import dev.yuyuyuyuyu.notpullingprobabilitycalculator.ui.main.MainScreen
 
@@ -12,9 +14,9 @@ import dev.yuyuyuyuyu.notpullingprobabilitycalculator.ui.main.MainScreen
 fun App() {
     val appComponent = remember { createAppComponent() }
 
-    MyMaterialTheme {
-        MainScreen(
-            notPullingProbabilityCalculatorViewModel = appComponent.notPullingProbabilityCalculatorViewModel,
-        )
+    CompositionLocalProvider(LocalAppComponent provides appComponent) {
+        MyMaterialTheme {
+            MainScreen()
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/App.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/App.kt
@@ -10,7 +10,6 @@ import dev.yuyuyuyuyu.notpullingprobabilitycalculator.di.createAppComponent
 import dev.yuyuyuyuyu.notpullingprobabilitycalculator.ui.main.MainScreen
 
 @Composable
-@Preview
 fun App() {
     val appComponent = remember { createAppComponent() }
 
@@ -19,4 +18,10 @@ fun App() {
             MainScreen()
         }
     }
+}
+
+@Composable
+@Preview
+private fun AppPreview() {
+    App()
 }

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/Greeting.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/Greeting.kt
@@ -1,7 +1,0 @@
-package dev.yuyuyuyuyu.notpullingprobabilitycalculator
-
-class Greeting {
-    private val platform = getPlatform()
-
-    fun greet(): String = "Hello, ${platform.name}!"
-}

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/Platform.kt
@@ -1,7 +1,0 @@
-package dev.yuyuyuyuyu.notpullingprobabilitycalculator
-
-interface Platform {
-    val name: String
-}
-
-expect fun getPlatform(): Platform

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/di/LocalAppComponent.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/di/LocalAppComponent.kt
@@ -1,0 +1,13 @@
+package dev.yuyuyuyuyu.notpullingprobabilitycalculator.di
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * Provides the app's DI container to the composition. Provided once at the top of the
+ * tree (see App()), so any screen can resolve its own dependencies without the container
+ * being threaded through intermediate composables as a parameter.
+ */
+val LocalAppComponent =
+    staticCompositionLocalOf<AppComponent> {
+        error("LocalAppComponent not provided. Wrap content in CompositionLocalProvider(LocalAppComponent provides …).")
+    }

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/domain/useCases/CalculateNotPullingProbabilityUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/domain/useCases/CalculateNotPullingProbabilityUseCase.kt
@@ -14,15 +14,19 @@ class CalculateNotPullingProbabilityUseCase {
         odds: Double,
         numberOfTrials: Int,
     ): Result<Probability, DomainError> {
-        if (odds !in 0.0..100.0) {
+        if (odds !in 0.0..MAX_PERCENTAGE) {
             return Err(DomainError.InvalidOddsError)
         }
 
         return Ok(
             value =
                 Probability(
-                    notPulling = (1 - odds / 100).pow(numberOfTrials),
+                    notPulling = (1 - odds / MAX_PERCENTAGE).pow(numberOfTrials),
                 ),
         )
+    }
+
+    private companion object {
+        const val MAX_PERCENTAGE = 100.0
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/ui/main/MainNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/ui/main/MainNavigation.kt
@@ -2,15 +2,15 @@ package dev.yuyuyuyuyu.notpullingprobabilitycalculator.ui.main
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
+import dev.yuyuyuyuyu.notpullingprobabilitycalculator.di.LocalAppComponent
 import dev.yuyuyuyuyu.notpullingprobabilitycalculator.ui.notPullingProbabilityCalculator.NotPullingProbabilityCalculatorScreen
-import dev.yuyuyuyuyu.notpullingprobabilitycalculator.ui.notPullingProbabilityCalculator.NotPullingProbabilityCalculatorViewModel
 import dev.yuyuyuyuyu.notpullingprobabilitycalculator.ui.openSourceLicenses.OpenSourceLicensesScreen
 
 @Composable
 fun MainNavigation(
-    notPullingProbabilityCalculatorViewModel: NotPullingProbabilityCalculatorViewModel,
     backStack: MutableList<MainNavigationRoute>,
     modifier: Modifier = Modifier,
 ) {
@@ -22,8 +22,12 @@ fun MainNavigation(
             when (key) {
                 MainNavigationRoute.NotPullingProbabilityCalculator -> {
                     NavEntry(key) {
+                        // Resolve this screen's ViewModel where it is actually used,
+                        // pulling the container from the composition instead of having
+                        // it threaded down as a parameter.
+                        val appComponent = LocalAppComponent.current
                         NotPullingProbabilityCalculatorScreen(
-                            viewModel = notPullingProbabilityCalculatorViewModel,
+                            viewModel = viewModel { appComponent.notPullingProbabilityCalculatorViewModel },
                         )
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/ui/main/MainNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/ui/main/MainNavigation.kt
@@ -1,6 +1,7 @@
 package dev.yuyuyuyuyu.notpullingprobabilitycalculator.ui.main
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.NavEntry
@@ -11,7 +12,7 @@ import dev.yuyuyuyuyu.notpullingprobabilitycalculator.ui.openSourceLicenses.Open
 
 @Composable
 fun MainNavigation(
-    backStack: MutableList<MainNavigationRoute>,
+    backStack: SnapshotStateList<MainNavigationRoute>,
     modifier: Modifier = Modifier,
 ) {
     NavDisplay(

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/ui/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/ui/main/MainScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.saveable.rememberSerializable
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
@@ -20,7 +21,7 @@ import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun MainScreen(modifier: Modifier = Modifier) {
-    val backStack: MutableList<MainNavigationRoute> =
+    val backStack: SnapshotStateList<MainNavigationRoute> =
         rememberSerializable(serializer = SnapshotStateListSerializer()) {
             mutableStateListOf(MainNavigationRoute.NotPullingProbabilityCalculator)
         }

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/ui/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/ui/main/MainScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.testTag
 import androidx.savedstate.compose.serialization.serializers.SnapshotStateListSerializer
-import dev.yuyuyuyuyu.notpullingprobabilitycalculator.ui.notPullingProbabilityCalculator.NotPullingProbabilityCalculatorViewModel
 import dev.yuyuyuyuyu.simpleTopAppBar.SimpleTopAppBar
 import notpullingprobabilitycalculator.composeapp.generated.resources.Res
 import notpullingprobabilitycalculator.composeapp.generated.resources.app_name
@@ -20,10 +19,7 @@ import notpullingprobabilitycalculator.composeapp.generated.resources.open_sourc
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
-fun MainScreen(
-    notPullingProbabilityCalculatorViewModel: NotPullingProbabilityCalculatorViewModel,
-    modifier: Modifier = Modifier,
-) {
+fun MainScreen(modifier: Modifier = Modifier) {
     val backStack: MutableList<MainNavigationRoute> =
         rememberSerializable(serializer = SnapshotStateListSerializer()) {
             mutableStateListOf(MainNavigationRoute.NotPullingProbabilityCalculator)
@@ -66,7 +62,6 @@ fun MainScreen(
         },
     ) { innerPadding ->
         MainNavigation(
-            notPullingProbabilityCalculatorViewModel = notPullingProbabilityCalculatorViewModel,
             backStack = backStack,
             modifier = Modifier.padding(innerPadding),
         )

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/ui/notPullingProbabilityCalculator/NotPullingProbabilityCalculatorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/ui/notPullingProbabilityCalculator/NotPullingProbabilityCalculatorScreen.kt
@@ -40,6 +40,7 @@ fun NotPullingProbabilityCalculatorScreen(
     modifier: Modifier = Modifier,
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val focusManager = LocalFocusManager.current
 
     Box(
         modifier = modifier.fillMaxSize(),
@@ -49,70 +50,86 @@ fun NotPullingProbabilityCalculatorScreen(
             modifier = Modifier.width(IntrinsicSize.Max),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            val focusManager = LocalFocusManager.current
-
-            TextField(
+            OddsTextField(
                 value = uiState.odds,
-                onValueChange = {
-                    if (it.isNotEmpty() && it.toDoubleOrNull() == null) {
-                        return@TextField
-                    }
-                    viewModel.onOddsChange(it)
-                },
-                modifier = Modifier.fillMaxWidth().testTag("oddsTextField"),
-                label = { Text(stringResource(Res.string.odds_label)) },
-                placeholder = { Text(stringResource(Res.string.odds_placeholder)) },
-                keyboardOptions =
-                    KeyboardOptions.Default.copy(
-                        keyboardType = KeyboardType.Number,
-                        imeAction = ImeAction.Next,
-                    ),
-                maxLines = 1,
+                onValueChange = viewModel::onOddsChange,
             )
-
-            TextField(
+            NumberOfTrialsTextField(
                 value = uiState.numberOfTrials,
-                onValueChange = {
-                    if (it.isNotEmpty() && it.toIntOrNull() == null) {
-                        return@TextField
-                    }
-                    viewModel.onNumberOfTrialsChange(it)
-                },
-                modifier = Modifier.fillMaxWidth().testTag("trialsTextField"),
-                label = { Text(stringResource(Res.string.number_of_trials_label)) },
-                placeholder = { Text(stringResource(Res.string.number_of_trials_placeholder)) },
-                keyboardOptions =
-                    KeyboardOptions.Default.copy(
-                        keyboardType = KeyboardType.Number,
-                        imeAction = ImeAction.Done,
-                    ),
-                keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
-                maxLines = 1,
+                onValueChange = viewModel::onNumberOfTrialsChange,
+                onImeAction = { focusManager.clearFocus() },
             )
-
-            Column {
-                Text(stringResource(Res.string.not_pulling_probability_text))
-                Text(
-                    text =
-                        stringResource(
-                            Res.string.not_pulling_probability_value,
-                            uiState.notPullingProbability,
-                        ),
-                    modifier = Modifier.testTag("notPullingProbabilityValue"),
-                )
-
-                Spacer(Modifier.height(16.dp))
-
-                Text(stringResource(Res.string.pulling_probability_text))
-                Text(
-                    text =
-                        stringResource(
-                            Res.string.pulling_probability_value,
-                            uiState.pullingProbability,
-                        ),
-                    modifier = Modifier.testTag("pullingProbabilityValue"),
-                )
-            }
+            ProbabilityResults(
+                notPullingProbability = uiState.notPullingProbability,
+                pullingProbability = uiState.pullingProbability,
+            )
         }
+    }
+}
+
+@Composable
+private fun OddsTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TextField(
+        value = value,
+        onValueChange = { if (it.isEmpty() || it.toDoubleOrNull() != null) onValueChange(it) },
+        modifier = modifier.fillMaxWidth().testTag("oddsTextField"),
+        label = { Text(stringResource(Res.string.odds_label)) },
+        placeholder = { Text(stringResource(Res.string.odds_placeholder)) },
+        keyboardOptions =
+            KeyboardOptions.Default.copy(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Next,
+            ),
+        maxLines = 1,
+    )
+}
+
+@Composable
+private fun NumberOfTrialsTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    onImeAction: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TextField(
+        value = value,
+        onValueChange = { if (it.isEmpty() || it.toIntOrNull() != null) onValueChange(it) },
+        modifier = modifier.fillMaxWidth().testTag("trialsTextField"),
+        label = { Text(stringResource(Res.string.number_of_trials_label)) },
+        placeholder = { Text(stringResource(Res.string.number_of_trials_placeholder)) },
+        keyboardOptions =
+            KeyboardOptions.Default.copy(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Done,
+            ),
+        keyboardActions = KeyboardActions(onDone = { onImeAction() }),
+        maxLines = 1,
+    )
+}
+
+@Composable
+private fun ProbabilityResults(
+    notPullingProbability: String,
+    pullingProbability: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(stringResource(Res.string.not_pulling_probability_text))
+        Text(
+            text = stringResource(Res.string.not_pulling_probability_value, notPullingProbability),
+            modifier = Modifier.testTag("notPullingProbabilityValue"),
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        Text(stringResource(Res.string.pulling_probability_text))
+        Text(
+            text = stringResource(Res.string.pulling_probability_value, pullingProbability),
+            modifier = Modifier.testTag("pullingProbabilityValue"),
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/ui/notPullingProbabilityCalculator/NotPullingProbabilityCalculatorViewModelImpl.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/ui/notPullingProbabilityCalculator/NotPullingProbabilityCalculatorViewModelImpl.kt
@@ -52,8 +52,8 @@ class NotPullingProbabilityCalculatorViewModelImpl(
                         )
                     }
                 }.onErr {
-                    _uiState.update {
-                        it.copy(
+                    _uiState.update { state ->
+                        state.copy(
                             notPullingProbability = "",
                             pullingProbability = "",
                         )

--- a/composeApp/src/jsMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/Platform.js.kt
+++ b/composeApp/src/jsMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/Platform.js.kt
@@ -1,7 +1,0 @@
-package dev.yuyuyuyuyu.notpullingprobabilitycalculator
-
-class JsPlatform : Platform {
-    override val name: String = "Web with Kotlin/JS"
-}
-
-actual fun getPlatform(): Platform = JsPlatform()

--- a/composeApp/src/jvmMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/Platform.jvm.kt
@@ -1,7 +1,0 @@
-package dev.yuyuyuyuyu.notpullingprobabilitycalculator
-
-class JvmPlatform : Platform {
-    override val name: String = "JVM ${System.getProperty("java.version")}"
-}
-
-actual fun getPlatform(): Platform = JvmPlatform()

--- a/composeApp/src/wasmJsMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/Platform.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/dev/yuyuyuyuyu/notpullingprobabilitycalculator/Platform.wasmJs.kt
@@ -1,7 +1,0 @@
-package dev.yuyuyuyuyu.notpullingprobabilitycalculator
-
-class WasmPlatform : Platform {
-    override val name: String = "Web with Kotlin/Wasm"
-}
-
-actual fun getPlatform(): Platform = WasmPlatform()

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -19,6 +19,10 @@ style:
   MagicNumber:
     ignorePropertyDeclaration: true
     ignoreCompanionObjectPropertyDeclaration: true
+  # @Preview functions are tooling entry points, not dead code, even when private
+  # (which the Compose PreviewPublic rule requires them to be).
+  UnusedPrivateFunction:
+    ignoreAnnotated: ['Preview']
 
 naming:
   # @Composable functions are PascalCase by convention.

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,27 +1,45 @@
-config:
-  validation: true
-  warningsAsErrors: false
-
-potential-bugs:
-  active: true
-  UnreachableCode:
-    active: true
-  UnusedUnaryOperator:
-    active: true
-  UselessPostfixExpression:
-    active: true
+# Delta over detekt's bundled default rule set (buildUponDefaultConfig = true).
+#
+# Division of labor:
+#   - ktlint (via spotless) is the source of truth for formatting / layout.
+#     detekt rules that overlap with ktlint are turned off here so the two tools
+#     never disagree.
+#   - detekt owns code smells, complexity and potential bugs.
+#   - Compose-specific checks come from the io.nlopez.compose.rules:detekt plugin
+#     (the "Compose" rule set), which is left at its recommended defaults.
 
 style:
-  active: true
-  UnusedImport:
-    active: true
-  UnusedParameter:
-    active: true
-  UnusedPrivateClass:
-    active: true
-  UnusedPrivateFunction:
-    active: true
-  UnusedPrivateProperty:
-    active: true
-  UnusedVariable:
-    active: true
+  # Line length is enforced by ktlint (max_line_length).
+  MaxLineLength:
+    active: false
+  # Wildcard imports are governed by ktlint (no-wildcard-imports).
+  WildcardImport:
+    active: false
+  # Compose color/dimension declarations are full of literals.
+  MagicNumber:
+    ignorePropertyDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+
+naming:
+  # @Composable functions are PascalCase by convention.
+  FunctionNaming:
+    ignoreAnnotated: ['Composable']
+  # Allow PascalCase top-level constants (e.g. compose tokens).
+  TopLevelPropertyNaming:
+    constantPattern: '[A-Z][A-Za-z0-9]*'
+
+complexity:
+  # Composables routinely take many parameters, most with defaults.
+  LongParameterList:
+    ignoreDefaultParameters: true
+  # @Preview functions shouldn't count toward a file's function budget.
+  TooManyFunctions:
+    ignoreAnnotatedFunctions: ['Preview']
+
+# Compose rules (io.nlopez.compose.rules:detekt).
+Compose:
+  # LocalAppComponent is a deliberate, single DI entry point — sanction it so the
+  # "avoid new CompositionLocals" rule doesn't fight our chosen DI approach.
+  CompositionLocalAllowlist:
+    allowedCompositionLocals:
+      - LocalAppComponent

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 spotless = "8.6.0"
 detekt = "2.0.0-alpha.3"
+composeRulesDetekt = "0.5.9"
 ksp = "2.3.9"
 kotlin-inject = "0.9.0"
 agp = "9.2.1"
@@ -28,6 +29,7 @@ kotlinxSerialization = "1.11.0"
 composePwa = "0.6.1"
 
 [libraries]
+compose-rules-detekt = { module = "io.nlopez.compose.rules:detekt", version.ref = "composeRulesDetekt" }
 kotlin-inject-runtime = { module = "me.tatarka.inject:kotlin-inject-runtime-kmp", version.ref = "kotlin-inject" }
 kotlin-inject-compiler = { module = "me.tatarka.inject:kotlin-inject-compiler-ksp", version.ref = "kotlin-inject" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary

Repurposes **detekt** from a dead-code-only check into a general linter built on its
**default rule set**, adds **Compose-specific rules**, and conforms the code to the new
findings (without a baseline).

Division of labor:
- **ktlint (via spotless)** — single source of truth for formatting / layout.
- **detekt** — code smells, complexity, potential bugs (`buildUponDefaultConfig = true`).
- **compose-rules** (`io.nlopez.compose.rules:detekt`) — Compose-specific checks.

In detekt 2.0 the ktlint-wrapper/formatting rules are opt-in, so the default rule set produced
**zero** conflicts with ktlint; `config/detekt/detekt.yml` only carries small deltas (a couple
of rules disabled to defer to ktlint, plus Compose-friendly tweaks).

## Tooling changes

- `buildUponDefaultConfig = true`; `detekt.yml` reduced to deltas only.
- Add `io.nlopez.compose.rules:detekt` 0.5.9 (matches detekt 2.0.0-alpha.3 / Kotlin 2.3.21).
- Exclude generated sources; add an aggregate `detektAll` task (type resolution where available).
- Disable detekt rules that overlap ktlint (`MaxLineLength`, `WildcardImport`); drop the unused
  `.editorconfig` wildcard-import override.

## Notable refactor: resolve the ViewModel at the navigation destination

Previously the screen's `ViewModel` was created at the top and threaded through
`MainScreen -> MainNavigation -> Screen` (flagged by Compose `ViewModelForwarding`). Now the DI
container is provided once via a `LocalAppComponent` CompositionLocal, and the `ViewModel` is
resolved where it is used (inside the `NavEntry`) with `viewModel { ... }`. `MainScreen` and
`MainNavigation` are now ViewModel-agnostic.

`LocalAppComponent` is registered in `Compose > CompositionLocalAllowlist` as the sanctioned DI
entry point (compose-rules intentionally discourages both VM forwarding and ad-hoc
CompositionLocals).

## Findings resolved in code (no baseline)

- Removed unused KMP template scaffolding (`Greeting` / `Platform` + actuals) — also clears
  `MatchingDeclarationName`.
- `PreviewPublic`: `@Preview` functions made private; dropped `@Preview` from production `App()`;
  taught `UnusedPrivateFunction` to ignore `@Preview`.
- `MutableParams`: `backStack` typed as `SnapshotStateList` instead of `MutableList`.
- `MagicNumber`: extracted the `100.0` percentage bound to a named constant.
- `LongMethod`: extracted `OddsTextField` / `NumberOfTrialsTextField` / `ProbabilityResults`
  sub-composables so the screen reads as a summary.
- `NoNameShadowing`: named the inner `update` lambda parameter.

## Verification

| spotless (ktlint) | detektAll | compile (wasmJs / jvm / android) | jvmTest | wasmJsTest |
|---|---|---|---|---|
| ✅ | ✅ 0 findings | ✅ | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)