### PR TITLE
ci: auto-merge Dependabot PRs on green CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  merge_group:
 
 jobs:
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
 
 jobs:
   format:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,9 +2,9 @@ name: Dependabot auto-merge
 
 # Turns on GitHub's native auto-merge for Dependabot PRs as soon as they open,
 # so they merge automatically once the required checks pass. Branch protection
-# still applies, and with the merge queue enabled the PR is rebased and
-# re-tested against the latest main before it lands. No human review is required
-# (this is the "auto-merge on green CI" trial variant).
+# still applies (including "up to date with main"), so if the PR falls behind,
+# Dependabot rebases it and CI re-runs before it lands. No human review is
+# required (this is the "auto-merge on green CI" trial variant).
 on: pull_request
 
 permissions:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+
+# Turns on GitHub's native auto-merge for Dependabot PRs as soon as they open,
+# so they merge automatically once the required checks pass. Branch protection
+# still applies, and with the merge queue enabled the PR is rebased and
+# re-tested against the latest main before it lands. No human review is required
+# (this is the "auto-merge on green CI" trial variant).
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,10 +1,6 @@
 name: Dependabot auto-merge
 
-# Turns on GitHub's native auto-merge for Dependabot PRs as soon as they open,
-# so they merge automatically once the required checks pass. Branch protection
-# still applies (including "up to date with main"), so if the PR falls behind,
-# Dependabot rebases it and CI re-runs before it lands. No human review is
-# required (this is the "auto-merge on green CI" trial variant).
+# Enable auto-merge on Dependabot PRs as soon as they open.
 on: pull_request
 
 permissions:


### PR DESCRIPTION
## What
Add `.github/workflows/dependabot-auto-merge.yml` that enables GitHub's native auto-merge on Dependabot PRs **as soon as they open**, so they merge automatically once the required checks pass.

## Behavior (trial variant: auto-merge on green CI)
Dependabot opens a PR → auto-merge is enabled → once the required checks pass (and the branch is up to date; Dependabot keeps its single PR rebased), it merges. **No human review.** This is the most-automated trial variant.

## Note
Merge queue turned out to be unavailable on personal-account repos, so the earlier `merge_group` trigger was removed — this PR is now just the auto-merge workflow. Combined with the Dependabot open-PR limit of 1, only one PR flows at a time, so there's no parallel-CI churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)