### PR TITLE
ci: lint workflow files with actionlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,26 @@ on:
     branches: [ "main" ]
 
 jobs:
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # actionlint has no first-party GitHub Action, so its authors recommend the
+      # download script. Fetching the latest release each run keeps this current
+      # without a pinned version for Dependabot to bump, and the binary exits
+      # non-zero on findings so lint errors fail the job.
+      - name: Download actionlint
+        id: actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+
+      - name: Lint workflow files
+        run: ${{ steps.actionlint.outputs.executable }} -color
+
   format:
     name: Format
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add an actionlint job to catch GitHub Actions workflow mistakes that
GitHub otherwise only surfaces at run time. Uses actionlint's officially
recommended download script rather than a pinned third-party action.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QViQD8nz9VqTkJZ5T7QXyS