### PR TITLE
ci: add daily yarn.lock refresh workflow, and stop the JetBrains JDK rate limiting

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,0 +1,18 @@
+name: Setup build
+description: JDK and Gradle, needed by every job that builds this repository.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup JDK
+      uses: actions/setup-java@v5
+      with:
+        java-version: "21"
+        distribution: "jetbrains"
+      # The JetBrains distribution resolves its version via the GitHub API;
+      # authenticate so it isn't throttled by the 60 req/hour/IP limit.
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,20 +36,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup JDK
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'jetbrains'
+      - name: Setup build
+        uses: ./.github/actions/setup-build
 
       # Spotless runs Prettier (web + TOML formatting) via Node/npm.
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
           node-version: '24'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
 
       - name: Check formatting
         run: ./gradlew spotlessCheck
@@ -71,14 +65,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup JDK
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'jetbrains'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+      - name: Setup build
+        uses: ./.github/actions/setup-build
 
       - name: Run detekt
         run: ./gradlew :composeApp:detektAll
@@ -92,14 +80,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup JDK
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'jetbrains'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+      - name: Setup build
+        uses: ./.github/actions/setup-build
 
       - name: Run tests
         run: ./gradlew wasmJsTest
@@ -113,14 +95,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup JDK
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'jetbrains'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+      - name: Setup build
+        uses: ./.github/actions/setup-build
 
       - name: Export Library Definitions
         run: ./gradlew :composeApp:exportLibraryDefinitions -PaboutLibraries.exportPath=src/commonMain/composeResources/files/

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -16,11 +16,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # gradle/actions/dependency-submission sets up Gradle itself, so this job
+      # needs the JDK alone rather than the setup-build composite action.
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'jetbrains'
+        # The JetBrains distribution resolves its version via the GitHub API;
+        # authenticate so it isn't throttled by the 60 req/hour/IP limit.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Send dependencies to Dependabot
         uses: gradle/actions/dependency-submission@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,14 +22,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup JDK
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'jetbrains'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+      - name: Setup build
+        uses: ./.github/actions/setup-build
 
       - name: Export Library Definitions
         run: ./gradlew :composeApp:exportLibraryDefinitions -PaboutLibraries.exportPath=src/commonMain/composeResources/files/

--- a/.github/workflows/refresh-yarn-lock.yml
+++ b/.github/workflows/refresh-yarn-lock.yml
@@ -1,0 +1,98 @@
+name: Refresh yarn.lock
+
+# Dependabot cannot update kotlin-js-store/yarn.lock: the Kotlin Gradle Plugin
+# generates it and there is no package.json for the npm ecosystem to track. This
+# job refreshes it daily so security fixes released within the existing version
+# ranges get picked up, mirroring Dependabot's daily / one-PR-at-a-time cadence.
+on:
+  schedule:
+    - cron: "0 0 * * *" # daily, 00:00 UTC
+  workflow_dispatch:
+
+# Serialize scheduled and manual runs so two of them cannot race to push the
+# same branch. Let an in-flight run finish rather than cancelling it.
+concurrency:
+  group: refresh-yarn-lock
+  cancel-in-progress: false
+
+# Every step authenticates with LOCKFILE_PR_TOKEN, so the workflow's own
+# GITHUB_TOKEN needs no permissions. A PR opened by GITHUB_TOKEN would not
+# trigger the CI workflow, leaving the required checks forever pending; the PAT
+# is what lets CI run on the PR it opens.
+permissions: {}
+
+jobs:
+  refresh:
+    name: Refresh yarn.lock
+    runs-on: ubuntu-latest
+    steps:
+      # Skip the whole run while a refresh PR is still open, so an in-review PR is
+      # never force-updated and at most one is open at a time (as with Dependabot's
+      # open-pull-requests-limit: 1). The branch protection requires PRs to be up to
+      # date with main, and keeping to a single auto-PR avoids needless rebases.
+      - name: Check for an existing open PR
+        id: guard
+        env:
+          GH_TOKEN: ${{ secrets.LOCKFILE_PR_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          count=$(gh pr list --state open --head chore/refresh-yarn-lock --json number --jq 'length')
+          if [ "$count" -gt 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "A refresh PR is already open; skipping this run." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.guard.outputs.skip == 'false'
+        uses: actions/checkout@v7
+        with:
+          # Push and PR creation must use the PAT, not GITHUB_TOKEN, so CI runs.
+          token: ${{ secrets.LOCKFILE_PR_TOKEN }}
+
+      - name: Setup JDK
+        if: steps.guard.outputs.skip == 'false'
+        uses: actions/setup-java@v5
+        with:
+          java-version: "21"
+          distribution: "jetbrains"
+
+      - name: Setup Gradle
+        if: steps.guard.outputs.skip == 'false'
+        uses: gradle/actions/setup-gradle@v6
+
+      # kotlinUpgradeYarnLock on its own only reconciles the stored lockfile with
+      # the declared dependencies; kotlinRestoreYarnLock copies it into build/ first
+      # and yarn then keeps the existing resolutions. Deleting the lockfiles forces a
+      # fresh resolve, which is what actually picks up in-range updates. Regenerating
+      # an unchanged tree is a no-op, so days with no update produce no diff.
+      - name: Refresh lockfiles
+        if: steps.guard.outputs.skip == 'false'
+        run: |
+          rm -f kotlin-js-store/yarn.lock kotlin-js-store/wasm/yarn.lock \
+                build/js/yarn.lock build/wasm/yarn.lock
+          ./gradlew kotlinUpgradeYarnLock kotlinWasmUpgradeYarnLock
+
+      - name: Open a PR when the lockfile changed
+        if: steps.guard.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.LOCKFILE_PR_TOKEN }}
+        run: |
+          if git diff --quiet -- kotlin-js-store; then
+            echo "No in-range npm updates today." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c chore/refresh-yarn-lock
+          git add kotlin-js-store
+          git commit -m "chore(deps): refresh yarn.lock to pick up in-range npm updates"
+          # No open PR on this branch is guaranteed by the guard step, so overwriting
+          # any leftover branch from a merged PR is safe.
+          git push --force origin chore/refresh-yarn-lock
+          gh pr create \
+            --base main \
+            --head chore/refresh-yarn-lock \
+            --title "chore(deps): refresh yarn.lock to pick up in-range npm updates" \
+            --body "Automated daily refresh of \`kotlin-js-store/yarn.lock\`, regenerated from a fresh resolve so it picks up npm releases that fit the existing version ranges. Dependabot cannot open this PR: the Kotlin Gradle Plugin generates the lockfile and there is no \`package.json\` for it to track. See \`.github/workflows/refresh-yarn-lock.yml\`."

--- a/.github/workflows/refresh-yarn-lock.yml
+++ b/.github/workflows/refresh-yarn-lock.yml
@@ -51,16 +51,9 @@ jobs:
           # Push and PR creation must use the PAT, not GITHUB_TOKEN, so CI runs.
           token: ${{ secrets.LOCKFILE_PR_TOKEN }}
 
-      - name: Setup JDK
+      - name: Setup build
         if: steps.guard.outputs.skip == 'false'
-        uses: actions/setup-java@v5
-        with:
-          java-version: "21"
-          distribution: "jetbrains"
-
-      - name: Setup Gradle
-        if: steps.guard.outputs.skip == 'false'
-        uses: gradle/actions/setup-gradle@v6
+        uses: ./.github/actions/setup-build
 
       # kotlinUpgradeYarnLock on its own only reconciles the stored lockfile with
       # the declared dependencies; kotlinRestoreYarnLock copies it into build/ first


### PR DESCRIPTION
Two CI changes. They are in one PR because this repo runs one auto-update PR at
a time — the ruleset requires branches to be up to date with main, so a second
concurrent PR would only force a rebase.

---

## 1. Daily `yarn.lock` refresh workflow

Adds `.github/workflows/refresh-yarn-lock.yml`, a scheduled workflow that keeps
`kotlin-js-store/yarn.lock` current with npm releases inside its existing
version ranges.

### Why

Dependabot cannot touch this lockfile — the Kotlin Gradle Plugin generates it
and there is no `package.json` for the npm ecosystem to track — so security
fixes that fit within existing ranges have no automated path in. PR #87 cleared
17 of 27 alerts by refreshing it once by hand; this makes that a daily job.

### How it works

- **Daily `cron` + `workflow_dispatch`.** One PR at a time: a guard step skips
  the run while a refresh PR is still open, so an in-review PR is never
  force-updated — matching Dependabot's `open-pull-requests-limit: 1`, which
  this repo runs to avoid rebase churn.
- **Delete-then-resolve.** `kotlinUpgradeYarnLock` on its own does *not* upgrade
  anything: `kotlinRestoreYarnLock` copies the stored lockfile into `build/`
  first and yarn keeps the existing resolutions. The job deletes the lockfiles
  before running the task to force a fresh resolve. Verified locally: on an
  already-current tree this produces an empty diff, so quiet days open no PR.

### Required setup (repository secret)

The workflow authenticates with a **`LOCKFILE_PR_TOKEN`** secret. This is
necessary, not optional: a PR opened with the default `GITHUB_TOKEN` does **not**
trigger the CI workflow, so the required checks would stay pending forever and
the PR could never merge. A PAT makes CI run on the PR.

Create a **fine-grained PAT** scoped to this repository with **Contents: Read and
write** and **Pull requests: Read and write**, then add it as an Actions secret
named `LOCKFILE_PR_TOKEN`. (`actions/create-github-app-token` is the no-expiry
alternative.)

Until the secret exists the scheduled job fails at its first step; merging this
PR is safe regardless, since the workflow only runs on schedule/dispatch.

---

## 2. Authenticate the JetBrains JDK download

`actions/setup-java` resolves the JetBrains distribution's version through the
GitHub API and makes that request unauthenticated, so it is throttled by the
60 req/hour/IP limit shared across GitHub-hosted runners. This has already
failed three jobs (#87 Build, #89 Format), each recoverable only by re-running.
Passing `github.token` raises the limit and removes the flake.

The JDK + Gradle pair was duplicated across six jobs, so it moves into a
`setup-build` composite action, matching the pattern already used in
`yuyuyuyuyu-dev/ComposePWA`. The Dependabot job keeps a standalone `setup-java`
with the same token, because `gradle/actions/dependency-submission` sets up
Gradle itself and would make the composite's Gradle step redundant.

Net effect on the workflows: 18 insertions, 49 deletions.

---

## Validation

`actionlint` (same tool and version as the CI lint job) passes across all
workflows and the new composite action with no findings. The rest is verified by
this PR's own CI run, which now exercises the composite action in every job.