### PR TITLE
ci: move the yarn.lock refresh off the most contended cron slot

### DIFF
--- a/.github/workflows/refresh-yarn-lock.yml
+++ b/.github/workflows/refresh-yarn-lock.yml
@@ -6,7 +6,11 @@ name: Refresh yarn.lock
 # ranges get picked up, mirroring Dependabot's daily / one-PR-at-a-time cadence.
 on:
   schedule:
-    - cron: "0 0 * * *" # daily, 00:00 UTC
+    # 21:41 UTC = 06:41 JST, so a refresh PR is waiting at the start of the day.
+    # Deliberately not on the hour and away from 00:00 UTC: those slots are the
+    # most contended on Actions, and GitHub delays or silently drops scheduled
+    # runs under load. The first "0 0 * * *" run never fired at all.
+    - cron: "41 21 * * *"
   workflow_dispatch:
 
 # Serialize scheduled and manual runs so two of them cannot race to push the


### PR DESCRIPTION
## What

Changes the `Refresh yarn.lock` schedule from `0 0 * * *` to `41 21 * * *`.

## Why

**The first scheduled run never fired.** The workflow was merged in #89 on
2026-07-25, so the schedule was due at 2026-07-26 00:00 UTC. Two hours past that
time there was no run of any kind for it.

Everything else checked out, which isolates the cause to the cron expression:

- `GET /actions/workflows` reports the workflow as `state: active` on the default
  branch
- the manual `workflow_dispatch` run on 2026-07-25 succeeded end to end and opened
  #91, so the job body, the PAT and the guard step all work
- the repository is active daily, so the 60-day inactivity auto-disable does not
  apply

`0 0 * * *` is midnight UTC on the hour — the most contended slot on Actions,
where scheduled runs are delayed under load and can be dropped outright.

`21:41 UTC` = `06:41 JST` preserves the original intent, a refresh PR waiting at
the start of the working day, while sitting away from both midnight UTC and the
top of any hour.

## Note on reliability

Scheduled runs can still be skipped occasionally — that is inherent to Actions
`schedule`. For a daily lockfile refresh a missed day is harmless: the next run
picks up everything, since the job always resolves from scratch rather than
replaying a queue. `workflow_dispatch` remains available to force a run.

## Validation

- `actionlint` passes with no findings.